### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/bibliography_auto.bib
+++ b/bibliography_auto.bib
@@ -8,7 +8,7 @@
 	 altmetric = {19},
 	 citations = {0},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1101/312918},
+	 url = {https://doi.org/10.1101/312918},
 	 keywords = {preprint}
 }
 
@@ -20,7 +20,7 @@
 	 altmetric = {10},
 	 citations = {1},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1101/147314},
+	 url = {https://doi.org/10.1101/147314},
 	 keywords = {preprint}
 }
 
@@ -36,7 +36,7 @@
 	 altmetric = {2},
 	 citations = {-},
 	 fcr = {-},
-	 url = {http://dx.doi.org/10.7717/peerj.4836},
+	 url = {https://doi.org/10.7717/peerj.4836},
 	 keywords = {accepted}
 }
 
@@ -48,7 +48,7 @@
 	 altmetric = {24},
 	 citations = {0},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1104/pp.17.01648},
+	 url = {https://doi.org/10.1104/pp.17.01648},
 	 keywords = {accepted}
 }
 
@@ -60,7 +60,7 @@
 	 altmetric = {70},
 	 citations = {2},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1093/aob/mcx221},
+	 url = {https://doi.org/10.1093/aob/mcx221},
 	 keywords = {accepted}
 }
 
@@ -72,7 +72,7 @@
 	 altmetric = {0},
 	 citations = {0},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1007/s11104-018-3595-8},
+	 url = {https://doi.org/10.1007/s11104-018-3595-8},
 	 keywords = {accepted}
 }
 
@@ -84,7 +84,7 @@
 	 altmetric = {36},
 	 citations = {2},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.12688/f1000research.13541.1},
+	 url = {https://doi.org/10.12688/f1000research.13541.1},
 	 keywords = {accepted}
 }
 
@@ -196,7 +196,7 @@
 	 altmetric = {24},
 	 citations = {6},
 	 fcr = {4.91},
-	 url = {http://dx.doi.org/10.1007/s11104-015-2673-4},
+	 url = {https://doi.org/10.1007/s11104-015-2673-4},
 	 keywords = {accepted}
 }
 
@@ -272,7 +272,7 @@
 	 altmetric = {1},
 	 citations = {8},
 	 fcr = {1.69},
-	 url = {http://dx.doi.org/10.1016/j.ecolmodel.2013.11.025},
+	 url = {https://doi.org/10.1016/j.ecolmodel.2013.11.025},
 	 keywords = {accepted}
 }
 
@@ -284,7 +284,7 @@
 	 altmetric = {-},
 	 citations = {6},
 	 fcr = {1.27},
-	 url = {http://dx.doi.org/10.1007/s11104-013-1975-7},
+	 url = {https://doi.org/10.1007/s11104-013-1975-7},
 	 keywords = {accepted}
 }
 
@@ -390,7 +390,7 @@
 	 year = {2017},
 	 booktitle = {IPG Symposium},
 	 address = { Missouri,  USA},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.5089900.v1},
+	 url = {https://doi.org/10.6084/m9.figshare.5089900.v1},
 	 keywords = {invited}
 }
 
@@ -400,7 +400,7 @@
 	 year = {2016},
 	 booktitle = {Open Belgium Conference},
 	 address = { Antwerpen,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.3020170},
+	 url = {https://doi.org/10.6084/m9.figshare.3020170},
 	 keywords = {invited}
 }
 
@@ -410,7 +410,7 @@
 	 year = {2015},
 	 booktitle = {Communiquer sa recherche},
 	 address = { Brussels,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1057995},
+	 url = {https://doi.org/10.6084/m9.figshare.1057995},
 	 keywords = {invited}
 }
 
@@ -420,7 +420,7 @@
 	 year = {2015},
 	 booktitle = {Winter School on Root Phenotyping},
 	 address = { Jülich,  Germany},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1594792},
+	 url = {https://doi.org/10.6084/m9.figshare.1594792},
 	 keywords = {invited}
 }
 
@@ -430,7 +430,7 @@
 	 year = {2015},
 	 booktitle = {Let's Talk Science},
 	 address = { Leuven,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1057995},
+	 url = {https://doi.org/10.6084/m9.figshare.1057995},
 	 keywords = {invited}
 }
 
@@ -440,7 +440,7 @@
 	 year = {2015},
 	 booktitle = {Plant Image Analysis Problems and Solution},
 	 address = { Madison,  Wisconsin},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1169928},
+	 url = {https://doi.org/10.6084/m9.figshare.1169928},
 	 keywords = {invited}
 }
 
@@ -450,7 +450,7 @@
 	 year = {2015},
 	 booktitle = {Modeling plant development from the organ to the whole plant scale},
 	 address = { Montpellier,  France},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1379862},
+	 url = {https://doi.org/10.6084/m9.figshare.1379862},
 	 keywords = {invited}
 }
 
@@ -490,7 +490,7 @@
 	 year = {2012},
 	 booktitle = {International Workshop on Image Analysis Methods for Plant Science},
 	 address = { Nottingham,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.95665},
+	 url = {https://doi.org/10.6084/m9.figshare.95665},
 	 keywords = {invited}
 }
 
@@ -500,7 +500,7 @@
 	 year = {2011},
 	 booktitle = {Roots for improving resource acquisition in crops},
 	 address = { Grasmere,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.95591},
+	 url = {https://doi.org/10.6084/m9.figshare.95591},
 	 keywords = {invited}
 }
 
@@ -514,7 +514,7 @@
 	 year = {2016},
 	 booktitle = {International Plant Phenotyping Symposium},
 	 address = { Mexico City,  Mexico},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.4311848.v1},
+	 url = {https://doi.org/10.6084/m9.figshare.4311848.v1},
 	 keywords = {spont}
 }
 
@@ -524,7 +524,7 @@
 	 year = {2016},
 	 booktitle = {CPIB Seminar},
 	 address = { Nottingham,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.4239140.v3},
+	 url = {https://doi.org/10.6084/m9.figshare.4239140.v3},
 	 keywords = {spont}
 }
 
@@ -534,7 +534,7 @@
 	 year = {2016},
 	 booktitle = {Neubias Taggathon},
 	 address = { Barcelona,  Spain (video-conference)},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.3826488},
+	 url = {https://doi.org/10.6084/m9.figshare.3826488},
 	 keywords = {spont}
 }
 
@@ -554,7 +554,7 @@
 	 year = {2014},
 	 booktitle = {International workshop on Image analysis methods for the plant sciences},
 	 address = { Aberythwyth,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1169928},
+	 url = {https://doi.org/10.6084/m9.figshare.1169928},
 	 keywords = {spont}
 }
 
@@ -564,7 +564,7 @@
 	 year = {2014},
 	 booktitle = {Genetic Variation of Flowering Time Genes and Applications for Crop Improvement},
 	 address = { Bielefeld,  Germany},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.976039},
+	 url = {https://doi.org/10.6084/m9.figshare.976039},
 	 keywords = {spont}
 }
 
@@ -574,7 +574,7 @@
 	 year = {2013},
 	 booktitle = {9th International Workshop on Sap Flow},
 	 address = { Ghent,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.713568},
+	 url = {https://doi.org/10.6084/m9.figshare.713568},
 	 keywords = {spont}
 }
 

--- a/tmp/bibliography_auto.bib
+++ b/tmp/bibliography_auto.bib
@@ -8,7 +8,7 @@
 	 altmetric = {19},
 	 citations = {0},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1101/312918},
+	 url = {https://doi.org/10.1101/312918},
 	 keywords = {preprint}
 }
 
@@ -20,7 +20,7 @@
 	 altmetric = {10},
 	 citations = {1},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1101/147314},
+	 url = {https://doi.org/10.1101/147314},
 	 keywords = {preprint}
 }
 
@@ -36,7 +36,7 @@
 	 altmetric = {2},
 	 citations = {-},
 	 fcr = {-},
-	 url = {http://dx.doi.org/10.7717/peerj.4836},
+	 url = {https://doi.org/10.7717/peerj.4836},
 	 keywords = {accepted}
 }
 
@@ -48,7 +48,7 @@
 	 altmetric = {24},
 	 citations = {0},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1104/pp.17.01648},
+	 url = {https://doi.org/10.1104/pp.17.01648},
 	 keywords = {accepted}
 }
 
@@ -60,7 +60,7 @@
 	 altmetric = {70},
 	 citations = {2},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1093/aob/mcx221},
+	 url = {https://doi.org/10.1093/aob/mcx221},
 	 keywords = {accepted}
 }
 
@@ -72,7 +72,7 @@
 	 altmetric = {0},
 	 citations = {0},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.1007/s11104-018-3595-8},
+	 url = {https://doi.org/10.1007/s11104-018-3595-8},
 	 keywords = {accepted}
 }
 
@@ -84,7 +84,7 @@
 	 altmetric = {36},
 	 citations = {2},
 	 fcr = {},
-	 url = {http://dx.doi.org/10.12688/f1000research.13541.1},
+	 url = {https://doi.org/10.12688/f1000research.13541.1},
 	 keywords = {accepted}
 }
 
@@ -196,7 +196,7 @@
 	 altmetric = {24},
 	 citations = {6},
 	 fcr = {4.91},
-	 url = {http://dx.doi.org/10.1007/s11104-015-2673-4},
+	 url = {https://doi.org/10.1007/s11104-015-2673-4},
 	 keywords = {accepted}
 }
 
@@ -272,7 +272,7 @@
 	 altmetric = {1},
 	 citations = {8},
 	 fcr = {1.69},
-	 url = {http://dx.doi.org/10.1016/j.ecolmodel.2013.11.025},
+	 url = {https://doi.org/10.1016/j.ecolmodel.2013.11.025},
 	 keywords = {accepted}
 }
 
@@ -284,7 +284,7 @@
 	 altmetric = {-},
 	 citations = {6},
 	 fcr = {1.27},
-	 url = {http://dx.doi.org/10.1007/s11104-013-1975-7},
+	 url = {https://doi.org/10.1007/s11104-013-1975-7},
 	 keywords = {accepted}
 }
 
@@ -390,7 +390,7 @@
 	 year = {2017},
 	 booktitle = {IPG Symposium},
 	 address = { Missouri,  USA},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.5089900.v1},
+	 url = {https://doi.org/10.6084/m9.figshare.5089900.v1},
 	 keywords = {invited}
 }
 
@@ -400,7 +400,7 @@
 	 year = {2016},
 	 booktitle = {Open Belgium Conference},
 	 address = { Antwerpen,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.3020170},
+	 url = {https://doi.org/10.6084/m9.figshare.3020170},
 	 keywords = {invited}
 }
 
@@ -410,7 +410,7 @@
 	 year = {2015},
 	 booktitle = {Communiquer sa recherche},
 	 address = { Brussels,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1057995},
+	 url = {https://doi.org/10.6084/m9.figshare.1057995},
 	 keywords = {invited}
 }
 
@@ -420,7 +420,7 @@
 	 year = {2015},
 	 booktitle = {Winter School on Root Phenotyping},
 	 address = { Jülich,  Germany},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1594792},
+	 url = {https://doi.org/10.6084/m9.figshare.1594792},
 	 keywords = {invited}
 }
 
@@ -430,7 +430,7 @@
 	 year = {2015},
 	 booktitle = {Let's Talk Science},
 	 address = { Leuven,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1057995},
+	 url = {https://doi.org/10.6084/m9.figshare.1057995},
 	 keywords = {invited}
 }
 
@@ -440,7 +440,7 @@
 	 year = {2015},
 	 booktitle = {Plant Image Analysis Problems and Solution},
 	 address = { Madison,  Wisconsin},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1169928},
+	 url = {https://doi.org/10.6084/m9.figshare.1169928},
 	 keywords = {invited}
 }
 
@@ -450,7 +450,7 @@
 	 year = {2015},
 	 booktitle = {Modeling plant development from the organ to the whole plant scale},
 	 address = { Montpellier,  France},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1379862},
+	 url = {https://doi.org/10.6084/m9.figshare.1379862},
 	 keywords = {invited}
 }
 
@@ -490,7 +490,7 @@
 	 year = {2012},
 	 booktitle = {International Workshop on Image Analysis Methods for Plant Science},
 	 address = { Nottingham,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.95665},
+	 url = {https://doi.org/10.6084/m9.figshare.95665},
 	 keywords = {invited}
 }
 
@@ -500,7 +500,7 @@
 	 year = {2011},
 	 booktitle = {Roots for improving resource acquisition in crops},
 	 address = { Grasmere,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.95591},
+	 url = {https://doi.org/10.6084/m9.figshare.95591},
 	 keywords = {invited}
 }
 
@@ -514,7 +514,7 @@
 	 year = {2016},
 	 booktitle = {International Plant Phenotyping Symposium},
 	 address = { Mexico City,  Mexico},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.4311848.v1},
+	 url = {https://doi.org/10.6084/m9.figshare.4311848.v1},
 	 keywords = {spont}
 }
 
@@ -524,7 +524,7 @@
 	 year = {2016},
 	 booktitle = {CPIB Seminar},
 	 address = { Nottingham,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.4239140.v3},
+	 url = {https://doi.org/10.6084/m9.figshare.4239140.v3},
 	 keywords = {spont}
 }
 
@@ -534,7 +534,7 @@
 	 year = {2016},
 	 booktitle = {Neubias Taggathon},
 	 address = { Barcelona,  Spain (video-conference)},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.3826488},
+	 url = {https://doi.org/10.6084/m9.figshare.3826488},
 	 keywords = {spont}
 }
 
@@ -554,7 +554,7 @@
 	 year = {2014},
 	 booktitle = {International workshop on Image analysis methods for the plant sciences},
 	 address = { Aberythwyth,  UK},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.1169928},
+	 url = {https://doi.org/10.6084/m9.figshare.1169928},
 	 keywords = {spont}
 }
 
@@ -564,7 +564,7 @@
 	 year = {2014},
 	 booktitle = {Genetic Variation of Flowering Time Genes and Applications for Crop Improvement},
 	 address = { Bielefeld,  Germany},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.976039},
+	 url = {https://doi.org/10.6084/m9.figshare.976039},
 	 keywords = {spont}
 }
 
@@ -574,7 +574,7 @@
 	 year = {2013},
 	 booktitle = {9th International Workshop on Sap Flow},
 	 address = { Ghent,  Belgium},
-	 url = {http://dx.doi.org/10.6084/m9.figshare.713568},
+	 url = {https://doi.org/10.6084/m9.figshare.713568},
 	 keywords = {spont}
 }
 

--- a/tmp/cv_g_lobet.bbl
+++ b/tmp/cv_g_lobet.bbl
@@ -46,7 +46,7 @@
       \verb 10.12688/f1000research.13541.1
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.12688/f1000research.13541.1
+      \verb https://doi.org/10.12688/f1000research.13541.1
       \endverb
       \keyw{accepted}
       \warn{\item Name "Topp, C, and, Lobet, G" has too many commas: skipping name}
@@ -119,7 +119,7 @@
       \verb 10.7717/peerj.4836
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.7717/peerj.4836
+      \verb https://doi.org/10.7717/peerj.4836
       \endverb
       \keyw{accepted}
     \endentry
@@ -178,7 +178,7 @@
       \verb 10.1007/s11104-018-3595-8
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-018-3595-8
+      \verb https://doi.org/10.1007/s11104-018-3595-8
       \endverb
       \keyw{accepted}
     \endentry
@@ -298,7 +298,7 @@
       \verb 10.1101/312918
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/312918
+      \verb https://doi.org/10.1101/312918
       \endverb
       \keyw{preprint}
     \endentry
@@ -368,7 +368,7 @@
       \verb 10.1104/pp.17.01648
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1104/pp.17.01648
+      \verb https://doi.org/10.1104/pp.17.01648
       \endverb
       \keyw{accepted}
     \endentry
@@ -441,7 +441,7 @@
       \verb 10.1093/aob/mcx221
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1093/aob/mcx221
+      \verb https://doi.org/10.1093/aob/mcx221
       \endverb
       \keyw{accepted}
     \endentry
@@ -543,7 +543,7 @@
       \verb 10.1101/147314
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/147314
+      \verb https://doi.org/10.1101/147314
       \endverb
       \keyw{preprint}
     \endentry
@@ -568,7 +568,7 @@
       \field{title}{Alternative plants, why we need models to understand the complexity of plants}
       \field{year}{2017}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.5089900.v1
+      \verb https://doi.org/10.6084/m9.figshare.5089900.v1
       \endverb
       \keyw{invited}
     \endentry
@@ -817,7 +817,7 @@
       \field{title}{How to deal with the complexity of plants, a modelling vision}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4239140.v3
+      \verb https://doi.org/10.6084/m9.figshare.4239140.v3
       \endverb
       \keyw{spont}
     \endentry
@@ -842,7 +842,7 @@
       \field{title}{Open Science. A view from the Bench}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3020170
+      \verb https://doi.org/10.6084/m9.figshare.3020170
       \endverb
       \keyw{invited}
     \endentry
@@ -867,7 +867,7 @@
       \field{title}{plant-image-analysis.org, A platform referencing plant image analysis tools}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3826488
+      \verb https://doi.org/10.6084/m9.figshare.3826488
       \endverb
       \keyw{spont}
     \endentry
@@ -892,7 +892,7 @@
       \field{title}{Using structural models to validate and improve root image analysis pipelines}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4311848.v1
+      \verb https://doi.org/10.6084/m9.figshare.4311848.v1
       \endverb
       \keyw{spont}
     \endentry
@@ -1012,7 +1012,7 @@
       \verb 10.1007/s11104-015-2673-4
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-015-2673-4
+      \verb https://doi.org/10.1007/s11104-015-2673-4
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, L, and, Delaplace, P" has too many commas: skipping name}
@@ -1063,7 +1063,7 @@
       \field{title}{Introducing Root System Markup Language}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1379862
+      \verb https://doi.org/10.6084/m9.figshare.1379862
       \endverb
       \keyw{invited}
     \endentry
@@ -1088,7 +1088,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{invited}
     \endentry
@@ -1113,7 +1113,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -1138,7 +1138,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -1163,7 +1163,7 @@
       \field{title}{Structural Root Modelling}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1594792
+      \verb https://doi.org/10.6084/m9.figshare.1594792
       \endverb
       \keyw{invited}
     \endentry
@@ -1385,7 +1385,7 @@
       \verb 10.1007/s11104-013-1975-7
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-013-1975-7
+      \verb https://doi.org/10.1007/s11104-013-1975-7
       \endverb
       \keyw{accepted}
       \warn{\item Name "Bielders, CL, and, Lutts, S" has too many commas: skipping name}
@@ -1413,7 +1413,7 @@
       \verb 10.1016/j.ecolmodel.2013.11.025
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1016/j.ecolmodel.2013.11.025
+      \verb https://doi.org/10.1016/j.ecolmodel.2013.11.025
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, P, and, Draye, X" has too many commas: skipping name}
@@ -1439,7 +1439,7 @@
       \field{title}{Inflorescence development in tomato. Gene functions within a zigzag model.}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.976039
+      \verb https://doi.org/10.6084/m9.figshare.976039
       \endverb
       \keyw{spont}
     \endentry
@@ -1489,7 +1489,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{spont}
     \endentry
@@ -1708,7 +1708,7 @@
       \field{title}{First steps towards an explicit modeling of aba production and translocation in relation with the water uptake dynamics}
       \field{year}{2013}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.713568
+      \verb https://doi.org/10.6084/m9.figshare.713568
       \endverb
       \keyw{spont}
     \endentry
@@ -1750,7 +1750,7 @@
       \field{title}{A Novel Image Analysis Toolbox Enabling Quantitative Analysis of Root System Architecture.}
       \field{year}{2012}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95665
+      \verb https://doi.org/10.6084/m9.figshare.95665
       \endverb
       \keyw{invited}
     \endentry
@@ -1803,7 +1803,7 @@
       \field{title}{New insights on the role of root radial conductivity on the overall uptake dynamics}
       \field{year}{2011}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95591
+      \verb https://doi.org/10.6084/m9.figshare.95591
       \endverb
       \keyw{invited}
     \endentry
@@ -1872,7 +1872,7 @@
       \verb 10.12688/f1000research.13541.1
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.12688/f1000research.13541.1
+      \verb https://doi.org/10.12688/f1000research.13541.1
       \endverb
       \keyw{accepted}
       \warn{\item Name "Topp, C, and, Lobet, G" has too many commas: skipping name}
@@ -1945,7 +1945,7 @@
       \verb 10.7717/peerj.4836
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.7717/peerj.4836
+      \verb https://doi.org/10.7717/peerj.4836
       \endverb
       \keyw{accepted}
     \endentry
@@ -2004,7 +2004,7 @@
       \verb 10.1007/s11104-018-3595-8
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-018-3595-8
+      \verb https://doi.org/10.1007/s11104-018-3595-8
       \endverb
       \keyw{accepted}
     \endentry
@@ -2124,7 +2124,7 @@
       \verb 10.1101/312918
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/312918
+      \verb https://doi.org/10.1101/312918
       \endverb
       \keyw{preprint}
     \endentry
@@ -2194,7 +2194,7 @@
       \verb 10.1104/pp.17.01648
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1104/pp.17.01648
+      \verb https://doi.org/10.1104/pp.17.01648
       \endverb
       \keyw{accepted}
     \endentry
@@ -2267,7 +2267,7 @@
       \verb 10.1093/aob/mcx221
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1093/aob/mcx221
+      \verb https://doi.org/10.1093/aob/mcx221
       \endverb
       \keyw{accepted}
     \endentry
@@ -2369,7 +2369,7 @@
       \verb 10.1101/147314
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/147314
+      \verb https://doi.org/10.1101/147314
       \endverb
       \keyw{preprint}
     \endentry
@@ -2394,7 +2394,7 @@
       \field{title}{Alternative plants, why we need models to understand the complexity of plants}
       \field{year}{2017}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.5089900.v1
+      \verb https://doi.org/10.6084/m9.figshare.5089900.v1
       \endverb
       \keyw{invited}
     \endentry
@@ -2643,7 +2643,7 @@
       \field{title}{How to deal with the complexity of plants, a modelling vision}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4239140.v3
+      \verb https://doi.org/10.6084/m9.figshare.4239140.v3
       \endverb
       \keyw{spont}
     \endentry
@@ -2668,7 +2668,7 @@
       \field{title}{Open Science. A view from the Bench}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3020170
+      \verb https://doi.org/10.6084/m9.figshare.3020170
       \endverb
       \keyw{invited}
     \endentry
@@ -2693,7 +2693,7 @@
       \field{title}{plant-image-analysis.org, A platform referencing plant image analysis tools}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3826488
+      \verb https://doi.org/10.6084/m9.figshare.3826488
       \endverb
       \keyw{spont}
     \endentry
@@ -2718,7 +2718,7 @@
       \field{title}{Using structural models to validate and improve root image analysis pipelines}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4311848.v1
+      \verb https://doi.org/10.6084/m9.figshare.4311848.v1
       \endverb
       \keyw{spont}
     \endentry
@@ -2838,7 +2838,7 @@
       \verb 10.1007/s11104-015-2673-4
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-015-2673-4
+      \verb https://doi.org/10.1007/s11104-015-2673-4
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, L, and, Delaplace, P" has too many commas: skipping name}
@@ -2889,7 +2889,7 @@
       \field{title}{Introducing Root System Markup Language}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1379862
+      \verb https://doi.org/10.6084/m9.figshare.1379862
       \endverb
       \keyw{invited}
     \endentry
@@ -2914,7 +2914,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{invited}
     \endentry
@@ -2939,7 +2939,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -2964,7 +2964,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -2989,7 +2989,7 @@
       \field{title}{Structural Root Modelling}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1594792
+      \verb https://doi.org/10.6084/m9.figshare.1594792
       \endverb
       \keyw{invited}
     \endentry
@@ -3211,7 +3211,7 @@
       \verb 10.1007/s11104-013-1975-7
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-013-1975-7
+      \verb https://doi.org/10.1007/s11104-013-1975-7
       \endverb
       \keyw{accepted}
       \warn{\item Name "Bielders, CL, and, Lutts, S" has too many commas: skipping name}
@@ -3239,7 +3239,7 @@
       \verb 10.1016/j.ecolmodel.2013.11.025
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1016/j.ecolmodel.2013.11.025
+      \verb https://doi.org/10.1016/j.ecolmodel.2013.11.025
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, P, and, Draye, X" has too many commas: skipping name}
@@ -3265,7 +3265,7 @@
       \field{title}{Inflorescence development in tomato. Gene functions within a zigzag model.}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.976039
+      \verb https://doi.org/10.6084/m9.figshare.976039
       \endverb
       \keyw{spont}
     \endentry
@@ -3315,7 +3315,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{spont}
     \endentry
@@ -3534,7 +3534,7 @@
       \field{title}{First steps towards an explicit modeling of aba production and translocation in relation with the water uptake dynamics}
       \field{year}{2013}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.713568
+      \verb https://doi.org/10.6084/m9.figshare.713568
       \endverb
       \keyw{spont}
     \endentry
@@ -3576,7 +3576,7 @@
       \field{title}{A Novel Image Analysis Toolbox Enabling Quantitative Analysis of Root System Architecture.}
       \field{year}{2012}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95665
+      \verb https://doi.org/10.6084/m9.figshare.95665
       \endverb
       \keyw{invited}
     \endentry
@@ -3629,7 +3629,7 @@
       \field{title}{New insights on the role of root radial conductivity on the overall uptake dynamics}
       \field{year}{2011}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95591
+      \verb https://doi.org/10.6084/m9.figshare.95591
       \endverb
       \keyw{invited}
     \endentry
@@ -3698,7 +3698,7 @@
       \verb 10.12688/f1000research.13541.1
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.12688/f1000research.13541.1
+      \verb https://doi.org/10.12688/f1000research.13541.1
       \endverb
       \keyw{accepted}
       \warn{\item Name "Topp, C, and, Lobet, G" has too many commas: skipping name}
@@ -3771,7 +3771,7 @@
       \verb 10.7717/peerj.4836
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.7717/peerj.4836
+      \verb https://doi.org/10.7717/peerj.4836
       \endverb
       \keyw{accepted}
     \endentry
@@ -3830,7 +3830,7 @@
       \verb 10.1007/s11104-018-3595-8
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-018-3595-8
+      \verb https://doi.org/10.1007/s11104-018-3595-8
       \endverb
       \keyw{accepted}
     \endentry
@@ -3950,7 +3950,7 @@
       \verb 10.1101/312918
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/312918
+      \verb https://doi.org/10.1101/312918
       \endverb
       \keyw{preprint}
     \endentry
@@ -4020,7 +4020,7 @@
       \verb 10.1104/pp.17.01648
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1104/pp.17.01648
+      \verb https://doi.org/10.1104/pp.17.01648
       \endverb
       \keyw{accepted}
     \endentry
@@ -4093,7 +4093,7 @@
       \verb 10.1093/aob/mcx221
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1093/aob/mcx221
+      \verb https://doi.org/10.1093/aob/mcx221
       \endverb
       \keyw{accepted}
     \endentry
@@ -4195,7 +4195,7 @@
       \verb 10.1101/147314
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/147314
+      \verb https://doi.org/10.1101/147314
       \endverb
       \keyw{preprint}
     \endentry
@@ -4220,7 +4220,7 @@
       \field{title}{Alternative plants, why we need models to understand the complexity of plants}
       \field{year}{2017}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.5089900.v1
+      \verb https://doi.org/10.6084/m9.figshare.5089900.v1
       \endverb
       \keyw{invited}
     \endentry
@@ -4469,7 +4469,7 @@
       \field{title}{How to deal with the complexity of plants, a modelling vision}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4239140.v3
+      \verb https://doi.org/10.6084/m9.figshare.4239140.v3
       \endverb
       \keyw{spont}
     \endentry
@@ -4494,7 +4494,7 @@
       \field{title}{Open Science. A view from the Bench}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3020170
+      \verb https://doi.org/10.6084/m9.figshare.3020170
       \endverb
       \keyw{invited}
     \endentry
@@ -4519,7 +4519,7 @@
       \field{title}{plant-image-analysis.org, A platform referencing plant image analysis tools}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3826488
+      \verb https://doi.org/10.6084/m9.figshare.3826488
       \endverb
       \keyw{spont}
     \endentry
@@ -4544,7 +4544,7 @@
       \field{title}{Using structural models to validate and improve root image analysis pipelines}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4311848.v1
+      \verb https://doi.org/10.6084/m9.figshare.4311848.v1
       \endverb
       \keyw{spont}
     \endentry
@@ -4664,7 +4664,7 @@
       \verb 10.1007/s11104-015-2673-4
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-015-2673-4
+      \verb https://doi.org/10.1007/s11104-015-2673-4
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, L, and, Delaplace, P" has too many commas: skipping name}
@@ -4715,7 +4715,7 @@
       \field{title}{Introducing Root System Markup Language}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1379862
+      \verb https://doi.org/10.6084/m9.figshare.1379862
       \endverb
       \keyw{invited}
     \endentry
@@ -4740,7 +4740,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{invited}
     \endentry
@@ -4765,7 +4765,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -4790,7 +4790,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -4815,7 +4815,7 @@
       \field{title}{Structural Root Modelling}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1594792
+      \verb https://doi.org/10.6084/m9.figshare.1594792
       \endverb
       \keyw{invited}
     \endentry
@@ -5037,7 +5037,7 @@
       \verb 10.1007/s11104-013-1975-7
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-013-1975-7
+      \verb https://doi.org/10.1007/s11104-013-1975-7
       \endverb
       \keyw{accepted}
       \warn{\item Name "Bielders, CL, and, Lutts, S" has too many commas: skipping name}
@@ -5065,7 +5065,7 @@
       \verb 10.1016/j.ecolmodel.2013.11.025
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1016/j.ecolmodel.2013.11.025
+      \verb https://doi.org/10.1016/j.ecolmodel.2013.11.025
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, P, and, Draye, X" has too many commas: skipping name}
@@ -5091,7 +5091,7 @@
       \field{title}{Inflorescence development in tomato. Gene functions within a zigzag model.}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.976039
+      \verb https://doi.org/10.6084/m9.figshare.976039
       \endverb
       \keyw{spont}
     \endentry
@@ -5141,7 +5141,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{spont}
     \endentry
@@ -5360,7 +5360,7 @@
       \field{title}{First steps towards an explicit modeling of aba production and translocation in relation with the water uptake dynamics}
       \field{year}{2013}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.713568
+      \verb https://doi.org/10.6084/m9.figshare.713568
       \endverb
       \keyw{spont}
     \endentry
@@ -5402,7 +5402,7 @@
       \field{title}{A Novel Image Analysis Toolbox Enabling Quantitative Analysis of Root System Architecture.}
       \field{year}{2012}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95665
+      \verb https://doi.org/10.6084/m9.figshare.95665
       \endverb
       \keyw{invited}
     \endentry
@@ -5455,7 +5455,7 @@
       \field{title}{New insights on the role of root radial conductivity on the overall uptake dynamics}
       \field{year}{2011}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95591
+      \verb https://doi.org/10.6084/m9.figshare.95591
       \endverb
       \keyw{invited}
     \endentry
@@ -5524,7 +5524,7 @@
       \verb 10.12688/f1000research.13541.1
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.12688/f1000research.13541.1
+      \verb https://doi.org/10.12688/f1000research.13541.1
       \endverb
       \keyw{accepted}
       \warn{\item Name "Topp, C, and, Lobet, G" has too many commas: skipping name}
@@ -5597,7 +5597,7 @@
       \verb 10.7717/peerj.4836
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.7717/peerj.4836
+      \verb https://doi.org/10.7717/peerj.4836
       \endverb
       \keyw{accepted}
     \endentry
@@ -5656,7 +5656,7 @@
       \verb 10.1007/s11104-018-3595-8
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-018-3595-8
+      \verb https://doi.org/10.1007/s11104-018-3595-8
       \endverb
       \keyw{accepted}
     \endentry
@@ -5776,7 +5776,7 @@
       \verb 10.1101/312918
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/312918
+      \verb https://doi.org/10.1101/312918
       \endverb
       \keyw{preprint}
     \endentry
@@ -5846,7 +5846,7 @@
       \verb 10.1104/pp.17.01648
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1104/pp.17.01648
+      \verb https://doi.org/10.1104/pp.17.01648
       \endverb
       \keyw{accepted}
     \endentry
@@ -5919,7 +5919,7 @@
       \verb 10.1093/aob/mcx221
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1093/aob/mcx221
+      \verb https://doi.org/10.1093/aob/mcx221
       \endverb
       \keyw{accepted}
     \endentry
@@ -6021,7 +6021,7 @@
       \verb 10.1101/147314
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1101/147314
+      \verb https://doi.org/10.1101/147314
       \endverb
       \keyw{preprint}
     \endentry
@@ -6046,7 +6046,7 @@
       \field{title}{Alternative plants, why we need models to understand the complexity of plants}
       \field{year}{2017}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.5089900.v1
+      \verb https://doi.org/10.6084/m9.figshare.5089900.v1
       \endverb
       \keyw{invited}
     \endentry
@@ -6295,7 +6295,7 @@
       \field{title}{How to deal with the complexity of plants, a modelling vision}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4239140.v3
+      \verb https://doi.org/10.6084/m9.figshare.4239140.v3
       \endverb
       \keyw{spont}
     \endentry
@@ -6320,7 +6320,7 @@
       \field{title}{Open Science. A view from the Bench}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3020170
+      \verb https://doi.org/10.6084/m9.figshare.3020170
       \endverb
       \keyw{invited}
     \endentry
@@ -6345,7 +6345,7 @@
       \field{title}{plant-image-analysis.org, A platform referencing plant image analysis tools}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.3826488
+      \verb https://doi.org/10.6084/m9.figshare.3826488
       \endverb
       \keyw{spont}
     \endentry
@@ -6370,7 +6370,7 @@
       \field{title}{Using structural models to validate and improve root image analysis pipelines}
       \field{year}{2016}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.4311848.v1
+      \verb https://doi.org/10.6084/m9.figshare.4311848.v1
       \endverb
       \keyw{spont}
     \endentry
@@ -6490,7 +6490,7 @@
       \verb 10.1007/s11104-015-2673-4
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-015-2673-4
+      \verb https://doi.org/10.1007/s11104-015-2673-4
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, L, and, Delaplace, P" has too many commas: skipping name}
@@ -6541,7 +6541,7 @@
       \field{title}{Introducing Root System Markup Language}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1379862
+      \verb https://doi.org/10.6084/m9.figshare.1379862
       \endverb
       \keyw{invited}
     \endentry
@@ -6566,7 +6566,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{invited}
     \endentry
@@ -6591,7 +6591,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -6616,7 +6616,7 @@
       \field{title}{Science Valorisation}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1057995
+      \verb https://doi.org/10.6084/m9.figshare.1057995
       \endverb
       \keyw{invited}
     \endentry
@@ -6641,7 +6641,7 @@
       \field{title}{Structural Root Modelling}
       \field{year}{2015}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1594792
+      \verb https://doi.org/10.6084/m9.figshare.1594792
       \endverb
       \keyw{invited}
     \endentry
@@ -6863,7 +6863,7 @@
       \verb 10.1007/s11104-013-1975-7
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1007/s11104-013-1975-7
+      \verb https://doi.org/10.1007/s11104-013-1975-7
       \endverb
       \keyw{accepted}
       \warn{\item Name "Bielders, CL, and, Lutts, S" has too many commas: skipping name}
@@ -6891,7 +6891,7 @@
       \verb 10.1016/j.ecolmodel.2013.11.025
       \endverb
       \verb{url}
-      \verb http://dx.doi.org/10.1016/j.ecolmodel.2013.11.025
+      \verb https://doi.org/10.1016/j.ecolmodel.2013.11.025
       \endverb
       \keyw{accepted}
       \warn{\item Name "Pagès, P, and, Draye, X" has too many commas: skipping name}
@@ -6917,7 +6917,7 @@
       \field{title}{Inflorescence development in tomato. Gene functions within a zigzag model.}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.976039
+      \verb https://doi.org/10.6084/m9.figshare.976039
       \endverb
       \keyw{spont}
     \endentry
@@ -6967,7 +6967,7 @@
       \field{title}{Plant Image Analysis tools. Current trends and limitations}
       \field{year}{2014}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.1169928
+      \verb https://doi.org/10.6084/m9.figshare.1169928
       \endverb
       \keyw{spont}
     \endentry
@@ -7186,7 +7186,7 @@
       \field{title}{First steps towards an explicit modeling of aba production and translocation in relation with the water uptake dynamics}
       \field{year}{2013}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.713568
+      \verb https://doi.org/10.6084/m9.figshare.713568
       \endverb
       \keyw{spont}
     \endentry
@@ -7228,7 +7228,7 @@
       \field{title}{A Novel Image Analysis Toolbox Enabling Quantitative Analysis of Root System Architecture.}
       \field{year}{2012}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95665
+      \verb https://doi.org/10.6084/m9.figshare.95665
       \endverb
       \keyw{invited}
     \endentry
@@ -7281,7 +7281,7 @@
       \field{title}{New insights on the role of root radial conductivity on the overall uptake dynamics}
       \field{year}{2011}
       \verb{url}
-      \verb http://dx.doi.org/10.6084/m9.figshare.95591
+      \verb https://doi.org/10.6084/m9.figshare.95591
       \endverb
       \keyw{invited}
     \endentry

--- a/update_citations_yaml_bib.R
+++ b/update_citations_yaml_bib.R
@@ -61,7 +61,7 @@ for(p in pubs){
       if(length(p$pmid) > 0){
         bib <-paste0(bib, "\t url = {http://www.ncbi.nlm.nih.gov/pubmed/",p$pmid,"},\n")
       }else{
-        bib <-paste0(bib, "\t url = {http://dx.doi.org/",p$doi,"},\n")
+        bib <-paste0(bib, "\t url = {https://doi.org/",p$doi,"},\n")
       }
       if(length(p$quote) > 0){
         bib <-paste0(bib, "\t quote = {",p$quote,"},\n")
@@ -131,7 +131,7 @@ for(p in pubs){
         if(length(p$pmid) > 0){
           bib <-paste0(bib, "\t url = {http://www.ncbi.nlm.nih.gov/pubmed/",p$pmid,"},\n")
         }else{
-          bib <-paste0(bib, "\t url = {http://dx.doi.org/",p$doi,"},\n")
+          bib <-paste0(bib, "\t url = {https://doi.org/",p$doi,"},\n")
         }
         if(length(p$quote) > 0){
           bib <-paste0(bib, "\t quote = {",p$quote,"},\n")


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!